### PR TITLE
patch: Validate length argument to be in [5-35]

### DIFF
--- a/Lesspass/Lesspass.psd1
+++ b/Lesspass/Lesspass.psd1
@@ -4,7 +4,7 @@
 RootModule = 'Lesspass.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.3'
+ModuleVersion = '1.0.4'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Lesspass/Lesspass.psm1
+++ b/Lesspass/Lesspass.psm1
@@ -13,7 +13,7 @@ function Get-LessPass {
         [Alias('nu')][Switch]$noUppercase,
         [Alias('nd')][Switch]$noDigits,
         [Alias('ns')][Switch]$noSymbols,
-        $length=1,
+        $length=16,
         $counter=1,
         # $prompt,
         # $clipboard,

--- a/Lesspass/Lesspass.psm1
+++ b/Lesspass/Lesspass.psm1
@@ -13,7 +13,7 @@ function Get-LessPass {
         [Alias('nu')][Switch]$noUppercase,
         [Alias('nd')][Switch]$noDigits,
         [Alias('ns')][Switch]$noSymbols,
-        $length=16,
+        [ValidateRange(5, 35)]$length=16,
         $counter=1,
         # $prompt,
         # $clipboard,

--- a/Lesspass/Lesspass.tests.ps1
+++ b/Lesspass/Lesspass.tests.ps1
@@ -5,5 +5,10 @@ Describe 'Get-LessPass' {
         It 'Run' {
             Get-LessPass "site" "login" "masterpassword" | Should -BeExactly 'cp$=}`taN2LZ=PF@'
         }
+
+        It 'Expects length in [5-35]' {
+            {Get-LessPass "site" "login" "masterpassword" -Length 2} `
+            | Should -Throw "Cannot validate argument on parameter 'length'. The 2 argument is less than the minimum allowed range"
+        }
     }
 }


### PR DESCRIPTION
**related:** https://github.com/lesspass/lesspass/issues/408
https://github.com/lesspass/lesspass/pull/410 https://github.com/lesspass/lesspass/commit/92aa4f20b2ada5257ba4c867a2cf8127f2664289

--- 

Align `-Length` behavior on Python CLI